### PR TITLE
Fixed default keymap

### DIFF
--- a/keyboards/hyper7/h7/v3/keymaps/default/keymap.c
+++ b/keyboards/hyper7/h7/v3/keymaps/default/keymap.c
@@ -523,7 +523,7 @@ void matrix_scan_keymap(void) {
 
 }
 
-bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   if (record->event.pressed) {
     switch(keycode) {
       // [daughter board] row 1 POS key macros


### PR DESCRIPTION

The default keymap was not producing output for the keys that use send_string("[FOO] key") 

<!--- Provide a general summary of your changes in the title above. -->

process_record_keymap() was not getting called, leaving many
keys not sending output. Changing to use process_record_user()
fixes this issue.


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
